### PR TITLE
Check for WIKI_CREATE permission, not authentication

### DIFF
--- a/newpage/templates/newpageform.html
+++ b/newpage/templates/newpageform.html
@@ -1,7 +1,7 @@
 <html xmlns:py="http://genshi.edgewall.org/" py:strip="">
 <div>
  <py:choose>
-  <py:when test="req.session.authenticated">
+  <py:when test="'WIKI_CREATE' in req.perm">
    <form id="${form}" method="GET" action="${req.href(parent,'__REPLACE_DYNAMICALLY__')}">
     <input type="text" placeholder="${placeholder}" id="${project}" />
     <input type="submit" value="${button}"/>


### PR DESCRIPTION
Anonymous users might have WIKI_CREATE, or authenticated users might not.

Come to think of it, it would probably be even more correct to check for a fine-grained permission, using the value of "parent" as the resource to check WIKI_CREATE against.  But I'm not totally sure if that's right...
