### PR TITLE
Allow basic [[NewPage]] usage without specifying a parent= parameter

### DIFF
--- a/newpage/macro.py
+++ b/newpage/macro.py
@@ -27,6 +27,9 @@ class NewPageMacro(WikiMacroBase):
         else:
             data["form"] = "new-project-form"
             data["project"] = "project-name"
+        if 'parent' not in data:
+            data["parent"] = "/wiki"
+
         self.log.debug("EXPAND ARGUMENTS: %s " % data)
         req = formatter.req
         template = Chrome(self.env).load_template('newpageform.html',method='xhtml')


### PR DESCRIPTION
Currently, if you don't specify a parent= parameter, the macro will still render without any apparent error, but the form it renders will contain a `<input type="hidden" name="parent" value="undefined" />` which will cause an error when it's used.

This patch makes parent= optional -- if it's absent, a default value of "/wiki" is assumed.

(And/or: would it make sense to prepend /wiki to any "parent" value that doesn't start with /wiki?  I'm not sure, but it seems like that could be a common error, especially since the "template" parameter is just a page name under `/wiki/PageTemplates` and not a full URL path.)
