### PR TITLE
Allow relative parent parameters, e.g. [[NewPage(parent=.)]]

### DIFF
--- a/newpage/macro.py
+++ b/newpage/macro.py
@@ -27,6 +27,12 @@ class NewPageMacro(WikiMacroBase):
         else:
             data["form"] = "new-project-form"
             data["project"] = "project-name"
+
+        if data["parent"].strip().rstrip("/") == ".":
+            data["parent"] = formatter.req.path_info
+        elif data["parent"].strip().rstrip("/") == "..":
+            data["parent"] = '/'.join(formatter.req.path_info.split("/")[:-1])
+            
         self.log.debug("EXPAND ARGUMENTS: %s " % data)
         req = formatter.req
         template = Chrome(self.env).load_template('newpageform.html',method='xhtml')


### PR DESCRIPTION
Two special cases are hardcoded:

[[NewPage(parent=.)]]

[[NewPage(parent=..)]]

These will be resolved to the current page and the current page's parent, respectively;
in other words, the first version allows you to render a "Create Child Page" form,
and the second version allows you to render a "Create Sibling Page" form.

It's entirely possible that this is a very silly feature .. but when they're put into a PageTemplate (which also specifies itself as the template) it seems like it could be pretty powerful.

On the other hand, if this feature is accepted, it's arguable that it should be generalized so that you could also say `[[NewPage(parent=../MySibling)]]` or `[[NewPage(parent=../../..)]` .. I dunno though, that seems like a whole can of worms.
